### PR TITLE
Add secondary buttons, accent link colors, and privacy-policy heading…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1085,7 +1085,113 @@ html.dark .btn-provider-action:active {
   background-color: var(--bg-dark);
   color: var(--accent) !important;
 }
+/* Provider action buttons container */
+.provider-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+/* Secondary blue button for providers page */
+.btn-provider-secondary {
+  display: inline-block;
+  background: var(--theme-blue-static);
+  color: white !important;
+  padding: 0.8rem 1.6rem;
+  border-radius: 5px;
+  text-decoration: none;
+  font-weight: 600;
+  text-align: center;
+  transition: background-color .2s, transform .2s;
+  border: none;
+  cursor: pointer;
+}
+
+.btn-provider-secondary:hover {
+  background-color: #1e2157;
+  transform: translateY(-2px);
+}
+
+.btn-provider-secondary:active {
+  background-color: var(--bg-light);
+  color: var(--theme-blue-static) !important;
+  transform: translateY(0);
+}
+
+html.dark .btn-provider-secondary {
+  background: var(--theme-blue-static);
+}
+
+html.dark .btn-provider-secondary:hover {
+  background-color: #1e2157;
+}
+
+html.dark .btn-provider-secondary:active {
+  background-color: var(--bg-dark);
+  color: var(--text-light) !important;
+}
+
 /* End of Styles for Provider Page Enhancements */
+
+/* Inline link colors for content-capsule sections */
+.content-capsule a:not(.btn):not(.btn-provider-action):not(.btn-provider-secondary):not(.provider-contact):not([download]) {
+  color: var(--accent);
+  text-decoration: underline;
+  transition: color 0.2s;
+}
+
+.content-capsule a:not(.btn):not(.btn-provider-action):not(.btn-provider-secondary):not(.provider-contact):not([download]):hover {
+  color: #C05F3E;
+}
+
+html.dark .content-capsule a:not(.btn):not(.btn-provider-action):not(.btn-provider-secondary):not(.provider-contact):not([download]) {
+  color: var(--accent);
+}
+
+html.dark .content-capsule a:not(.btn):not(.btn-provider-action):not(.btn-provider-secondary):not(.provider-contact):not([download]):hover {
+  color: #e0825e;
+}
+
+/* Privacy policy page heading overrides */
+.privacy-policy h2,
+.privacy-policy h3,
+.privacy-policy h4 {
+  font-family: 'Inter', sans-serif;
+  text-align: left;
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-bottom: none;
+  color: var(--heading-color);
+  padding: 0;
+  border-radius: 0;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.privacy-policy h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.privacy-policy h3 {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.privacy-policy h4 {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+html.dark .privacy-policy h2,
+html.dark .privacy-policy h3,
+html.dark .privacy-policy h4 {
+  color: var(--text-light);
+}
 
 /* Old mobile menu styles removed - using new .mobile-menu-btn in header CSS */
 

--- a/src/app/our-providers/page.js
+++ b/src/app/our-providers/page.js
@@ -1,4 +1,5 @@
 import Separator from '@/components/Separator';
+import Link from 'next/link';
 import Script from 'next/script';
 
 export const metadata = {
@@ -46,7 +47,10 @@ export default function OurProviders() {
             <div className="psychology-today-embed-wrapper">
               <a href="https://www.psychologytoday.com/profile/1226261" className="sx-verified-seal"></a>
             </div>
-            <a href="https://docs.google.com/forms/d/e/1FAIpQLSeeYABYxDoscWL3jH-SNU51X0hgomcb0bEqshRIUnCRg7aSgA/viewform" className="btn-provider-action" target="_blank" rel="noopener noreferrer">Book Appointment with Talia</a>
+            <div className="provider-actions">
+              <a href="https://docs.google.com/forms/d/e/1FAIpQLSeeYABYxDoscWL3jH-SNU51X0hgomcb0bEqshRIUnCRg7aSgA/viewform" className="btn-provider-action" target="_blank" rel="noopener noreferrer">Book Appointment with Talia</a>
+              <Link href="/privacy-policy" className="btn-provider-secondary">Privacy Policy</Link>
+            </div>
           </div>
         </section>
 
@@ -80,7 +84,10 @@ export default function OurProviders() {
             <div className="psychology-today-embed-wrapper">
               <a href="https://www.psychologytoday.com/profile/1233174" className="sx-verified-seal"></a>
             </div>
-            <a href="https://docs.google.com/forms/d/e/1FAIpQLSeeYABYxDoscWL3jH-SNU51X0hgomcb0bEqshRIUnCRg7aSgA/viewform" className="btn-provider-action" target="_blank" rel="noopener noreferrer">Book Appointment with Heidi</a>
+            <div className="provider-actions">
+              <a href="https://docs.google.com/forms/d/e/1FAIpQLSeeYABYxDoscWL3jH-SNU51X0hgomcb0bEqshRIUnCRg7aSgA/viewform" className="btn-provider-action" target="_blank" rel="noopener noreferrer">Book Appointment with Heidi</a>
+              <Link href="/privacy-policy" className="btn-provider-secondary">Privacy Policy</Link>
+            </div>
           </div>
         </section>
       </div>

--- a/src/app/privacy-policy/page.js
+++ b/src/app/privacy-policy/page.js
@@ -7,7 +7,7 @@ export const metadata = {
 
 export default function PrivacyPolicy() {
   return (
-    <div className="content-capsule" data-aos="fade-up">
+    <div className="content-capsule privacy-policy" data-aos="fade-up">
       <h2>Privacy Policy</h2>
       <p style={{ textAlign: 'center', marginBottom: '2rem', fontSize: '0.9rem', color: 'var(--text-dark)', opacity: 0.7 }}>
         Last updated: February 2026
@@ -44,7 +44,7 @@ export default function PrivacyPolicy() {
       <h3>Google Analytics</h3>
       <p>
         We use Google Analytics to understand how visitors interact with our website. Google Analytics collects information such as how often users visit the site, what pages they visit, and what other sites they used prior to coming to our site. We use this information solely to improve our website. Google Analytics does not collect your name or other personally identifying information. You can opt out of Google Analytics by installing the{' '}
-        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)', textDecoration: 'underline' }}>
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">
           Google Analytics Opt-out Browser Add-on
         </a>.
       </p>
@@ -74,8 +74,8 @@ export default function PrivacyPolicy() {
         If you have questions about this Privacy Policy or our privacy practices, please contact us:
       </p>
       <ul style={{ paddingLeft: '1.5rem', marginBottom: '1.5rem', lineHeight: '1.8', listStyle: 'none' }}>
-        <li><strong>Email:</strong> <a href="mailto:admin@awakeningsmentalhealth.com" style={{ color: 'var(--accent)', textDecoration: 'underline' }}>admin@awakeningsmentalhealth.com</a></li>
-        <li><strong>Phone:</strong> <a href="tel:2082950297" style={{ color: 'var(--accent)', textDecoration: 'underline' }}>(208) 295-0297</a></li>
+        <li><strong>Email:</strong> <a href="mailto:admin@awakeningsmentalhealth.com">admin@awakeningsmentalhealth.com</a></li>
+        <li><strong>Phone:</strong> <a href="tel:2082950297">(208) 295-0297</a></li>
         <li><strong>Address:</strong> 6126 W State St #104, Boise, ID 83703</li>
       </ul>
 


### PR DESCRIPTION
… overrides

- Providers page: wrapped each provider's buttons in .provider-actions flex container, added blue "Privacy Policy" secondary button next to each "Book Appointment" button
- CSS: .provider-actions flex wrapper, .btn-provider-secondary blue button with hover/active/dark-mode states
- CSS: .content-capsule inline links now use orange accent color with darker hover, works in both light and dark mode
- CSS: .privacy-policy h2/h3/h4 use Inter sans-serif (not Dancing Script), left-aligned, no background/box-shadow/border accents
- Privacy policy page: added .privacy-policy class, removed redundant inline link styles

https://claude.ai/code/session_01TQF5e8T6wyFot31rDZrxzY