### PR TITLE
Add second location (Meridian) to Our Locations section

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -858,6 +858,41 @@ html.dark .testimonial-dots .dot {
 body.scrolled #to-top { opacity: 1; } 
 section#location address { text-align: center; margin-top: 0.5rem; }
 
+#location h3 { text-align: center; margin-bottom: 0.25rem; }
+
+.locations-blurb {
+  text-align: center;
+  max-width: 680px;
+  margin: 0.75rem auto 0.5rem;
+  line-height: 1.6;
+}
+
+.locations-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.25rem;
+}
+
+.location-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.new-location-badge {
+  display: inline-block;
+  background-color: var(--accent);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  vertical-align: middle;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 footer#contact {
     text-align:center; 
     padding: 2.5rem 1rem 2rem; /* Increased padding for better spacing with shadow */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -872,6 +872,7 @@ section#location address { text-align: center; margin-top: 0.5rem; }
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
   margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
 }
 
 .location-card {

--- a/src/app/our-providers/page.js
+++ b/src/app/our-providers/page.js
@@ -48,7 +48,7 @@ export default function OurProviders() {
               <a href="https://www.psychologytoday.com/profile/1226261" className="sx-verified-seal"></a>
             </div>
             <div className="provider-actions">
-              <a href="https://docs.google.com/forms/d/e/1FAIpQLSeeYABYxDoscWL3jH-SNU51X0hgomcb0bEqshRIUnCRg7aSgA/viewform" className="btn-provider-action" target="_blank" rel="noopener noreferrer">Book Appointment with Talia</a>
+              <a href="https://sessions.psychologytoday.com/talia-sierra" className="btn-provider-action" target="_blank" rel="noopener noreferrer">Book Appointment with Talia</a>
               <Link href="/privacy-policy" className="btn-provider-secondary">Privacy Policy</Link>
             </div>
           </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -50,7 +50,7 @@ export default function Home() {
         <div className="content-capsule">
           <h2>Our Locations</h2>
           <p className="locations-blurb">
-            We now have two convenient locations to serve you! When booking an appointment, please make sure to select the correct location for your visit. Our original Boise office is still fully active, and we&apos;re excited to be adding our new Meridian location as well for your convenience.
+            We now have two convenient locations to serve you! Your appointment location will depend on your provider — in-person visits with Heidi are held at our Boise office, while in-person visits with Talia are held at our new Meridian location.
           </p>
           <div className="locations-grid">
             <div className="location-card">

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -50,7 +50,7 @@ export default function Home() {
         <div className="content-capsule">
           <h2>Our Locations</h2>
           <p className="locations-blurb">
-            We now have two convenient locations to serve you! Your appointment location will depend on your provider — in-person visits with Heidi are held at our Boise office, while in-person visits with Talia are held at our new Meridian location.
+            We now have two convenient locations to serve you! Your appointment location is provider specific. In-person visits with Heidi are held at our Boise office, and in-person visits with Talia are held at our new Meridian location.
           </p>
           <div className="locations-grid">
             <div className="location-card">

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -59,15 +59,6 @@ export default function Home() {
                 6126 W State St #104<br />
                 Boise, ID 83703
               </address>
-              <iframe
-                className="skeleton lazy-embed map-iframe-rounded"
-                loading="lazy"
-                src="https://maps.google.com/maps?q=6126%20W%20State%20St%20%23104%2C%20Boise%2C%20ID%2083703&t=&z=17&ie=UTF8&iwloc=&output=embed"
-                width="100%"
-                height="260"
-                style={{ border: 0 }}
-                allowFullScreen=""
-              />
             </div>
             <div className="location-card">
               <h3>Meridian <span className="new-location-badge">New</span></h3>
@@ -75,17 +66,17 @@ export default function Home() {
                 1510 W. Ustick Rd. #110<br />
                 Meridian, Idaho 83646
               </address>
-              <iframe
-                className="skeleton lazy-embed map-iframe-rounded"
-                loading="lazy"
-                src="https://maps.google.com/maps?q=1510%20W.%20Ustick%20Rd.%20%23110%2C%20Meridian%2C%20Idaho%2083646&t=&z=17&ie=UTF8&iwloc=&output=embed"
-                width="100%"
-                height="260"
-                style={{ border: 0 }}
-                allowFullScreen=""
-              />
             </div>
           </div>
+          <iframe
+            className="skeleton lazy-embed map-iframe-rounded"
+            src="https://www.google.com/maps/d/u/5/embed?mid=1rGi6IQQv3jW2n45mNB9oHQ-yCnKHYkE&ehbc=2E312F"
+            width="100%"
+            height="480"
+            style={{ border: 0 }}
+            allowFullScreen=""
+            loading="lazy"
+          />
         </div>
       </section>
 

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -48,25 +48,43 @@ export default function Home() {
 
       <section id="location" data-aos="fade-right">
         <div className="content-capsule">
-          <div className="grid-2" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1rem', alignItems: 'center' }}>
-            <div>
-              <h2>Our Location</h2>
-              <h3>
-                <address>
-                  6126 W State St #104<br />
-                  Boise, ID 83703
-                </address>
-              </h3>
+          <h2>Our Locations</h2>
+          <p className="locations-blurb">
+            We now have two convenient locations to serve you! When booking an appointment, please make sure to select the correct location for your visit. Our original Boise office is still fully active, and we&apos;re excited to be adding our new Meridian location as well for your convenience.
+          </p>
+          <div className="locations-grid">
+            <div className="location-card">
+              <h3>Boise</h3>
+              <address>
+                6126 W State St #104<br />
+                Boise, ID 83703
+              </address>
+              <iframe
+                className="skeleton lazy-embed map-iframe-rounded"
+                loading="lazy"
+                src="https://maps.google.com/maps?q=6126%20W%20State%20St%20%23104%2C%20Boise%2C%20ID%2083703&t=&z=17&ie=UTF8&iwloc=&output=embed"
+                width="100%"
+                height="260"
+                style={{ border: 0 }}
+                allowFullScreen=""
+              />
             </div>
-            <iframe
-              className="skeleton lazy-embed map-iframe-rounded"
-              loading="lazy"
-              src="https://maps.google.com/maps?q=6126%20W%20State%20St%20%23104%2C%20Boise%2C%20ID%2083703&t=&z=17&ie=UTF8&iwloc=&output=embed"
-              width="100%"
-              height="325"
-              style={{ border: 0 }}
-              allowFullScreen=""
-            />
+            <div className="location-card">
+              <h3>Meridian <span className="new-location-badge">New</span></h3>
+              <address>
+                1510 W. Ustick Rd. #110<br />
+                Meridian, Idaho 83646
+              </address>
+              <iframe
+                className="skeleton lazy-embed map-iframe-rounded"
+                loading="lazy"
+                src="https://maps.google.com/maps?q=1510%20W.%20Ustick%20Rd.%20%23110%2C%20Meridian%2C%20Idaho%2083646&t=&z=17&ie=UTF8&iwloc=&output=embed"
+                width="100%"
+                height="260"
+                style={{ border: 0 }}
+                allowFullScreen=""
+              />
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary

- Renamed "Our Location" to "Our Locations"
- Added Meridian address: 1510 W. Ustick Rd. #110, Meridian, Idaho 83646
- Added a blurb guiding patients to select the correct location when booking
- Added "New" badge on the Meridian location card
- Replaced two individual Google Maps iframes with a single shared Google My Maps iframe showing both pins

## Test plan

- [ ] Verify both Boise and Meridian addresses display correctly side-by-side
- [ ] Confirm the shared map iframe loads and shows both location pins
- [ ] Check "New" badge appears on the Meridian card
- [ ] Verify booking blurb text is visible and readable
- [ ] Test responsive layout on mobile and desktop