### PR TITLE
Fix provider action buttons stretching in height

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1146,6 +1146,7 @@ html.dark .btn-provider-action:active {
 .provider-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.75rem;
   margin-top: 1rem;
 }


### PR DESCRIPTION
Add align-items: center to .provider-actions flex container so buttons maintain their natural height instead of stretching to match each other.

https://claude.ai/code/session_019STmBqwyMccs2ZuPwVqEXz